### PR TITLE
Allow users to pick a starting letter

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ generate({ words: 4 }).raw; // ['tiny', 'crabby', 'wired', 'quicksand']
 
 generate({ words: 4, number: true }).dashed; // 'breakable-judicious-luxuriant-tax-3931'
 
-generate({ words: 2, alliterative: true }).spaced; // 'elegant experience'
+generate({ words: 2, startingLetter: 'e', alliterative: true }).spaced; // 'elegant experience'
 
 ```
 
@@ -52,6 +52,7 @@ Options:
   -w, --words [num]      number of words [2]
   -n, --numbers          use numbers
   -a, --alliterative     use alliterative
+  -l, --letter [letter]  specify first letter
   -o, --output [output]  output type [raw|dashed|spaced]
   -h, --help             output usage information
 ```
@@ -73,6 +74,7 @@ The `options` argument object can have properties
 * **words** (number) - Number of words generated (excluding number). All words will be adjectives, except the last one which will be a noun. Defaults to **2**.
 * **number** (boolean) - Whether a numeric suffix is generated or not. The number is between 1 - 9999, both inclusive. Defaults to **false**.
 * **alliterative** (boolean) - Whether to output words beginning with the same letter or not. Defaults to **false**.
+* **startingLetter** (string) - Specifies the letter to start the project name with. Defaults to **null**.
 
 `generate({ words: 3 })` will return:
 ```javascript
@@ -92,7 +94,7 @@ The `options` argument object can have properties
 }
 ```
 
-`generate({ words: 2, number: false, alliterative: true })` will return:
+`generate({ words: 2, number: false, startingLetter: 'e', alliterative: true })` will return:
 ```javascript
 {
   raw: [ 'elegant', 'experience' ],

--- a/src/generator-bin.js
+++ b/src/generator-bin.js
@@ -8,10 +8,11 @@ program
     .option('-w, --words [num]', 'number of words [2]', 2)
     .option('-n, --numbers', 'use numbers')
     .option('-a, --alliterative', 'use alliterative')
+    .option('-l, --letter [letter]', 'specify first letter')
     .option('-o, --output [output]', 'output type [raw|dashed|spaced]', /^(raw|dashed|spaced)$/i)
     .parse(process.argv)
 
-let project_name = generate({words: program.words, number: program.numbers, alliterative: program.alliterative});
+let project_name = generate({words: program.words, number: program.numbers, alliterative: program.alliterative, startingLetter: program.letter?program.letter.substring(0,1):null});
 
 if (program.output == "dashed"){
     console.log(project_name.dashed);

--- a/src/generator.js
+++ b/src/generator.js
@@ -30,7 +30,7 @@ function getRawProjName(options) {
     if (options.alliterative && raw.length)
       raw.push(_.sample(getAlliterativeMatches(adjectives, raw[0].substring(0, 1))));
     else
-      raw.push(_.sample(options.startingLetter?getAlliterativeMatches(adjectives, options.startingLetter):adjectives).toLowerCase());
+      raw.push(_.sample(options.startingLetter?getAlliterativeMatches(adjectives, options.startingLetter.substring(0,1).toLowerCase()):adjectives).toLowerCase());
   });
 
   if (options.alliterative)


### PR DESCRIPTION
This adds the functionality of setting the first letter of a project name (in the case that someone wants to iterate through letters for non-semver versioning, or something).

![screen shot 2017-11-07 at 11 53 36](https://user-images.githubusercontent.com/5731838/32492476-53a57956-c3b2-11e7-889f-a745c0fbe6c1.png)


There are no tests yet and it might be fragile in terms of unexpected input, but it does the job from my minimal usage of it.