### PR TITLE
Remove the word "hate"

### DIFF
--- a/src/nouns.js
+++ b/src/nouns.js
@@ -340,7 +340,6 @@ module.exports = [
   "harbor",
   "harmony",
   "hat",
-  "hate",
   "head",
   "health",
   "heat",


### PR DESCRIPTION
Some project names are generated as 'white-hate' or 'black-hate' and that's offensive