### PR TITLE
Allow specifying the length of digits to return in numeric suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ generate({ words: 4 }).raw; // ['tiny', 'crabby', 'wired', 'quicksand']
 
 generate({ words: 4, number: true }).dashed; // 'breakable-judicious-luxuriant-tax-3931'
 
+generate({ words: 2, number: 6 }).dashed; // 'arch-measure-24518'
+
 generate({ words: 2, alliterative: true }).spaced; // 'elegant experience'
 
 ```
@@ -50,7 +52,7 @@ Options:
 
   -V, --version          output the version number
   -w, --words [num]      number of words [2]
-  -n, --numbers          use numbers
+  -n, --numbers [num]    use numbers, number of digits
   -a, --alliterative     use alliterative
   -o, --output [output]  output type [raw|dashed|spaced]
   -h, --help             output usage information
@@ -71,7 +73,7 @@ Calling `generate()` with no arguments will return an object:
 The `options` argument object can have properties
 
 * **words** (number) - Number of words generated (excluding number). All words will be adjectives, except the last one which will be a noun. Defaults to **2**.
-* **number** (boolean) - Whether a numeric suffix is generated or not. The number is between 1 - 9999, both inclusive. Defaults to **false**.
+* **number** (number or boolean) - Whether a numeric suffix is generated or not. The length of digits can be between 1 - 20, inclusive of the exponential value between 1-1e#. Specifying `true` will specify a length of 4 digits. Defaults to **false**.
 * **alliterative** (boolean) - Whether to output words beginning with the same letter or not. Defaults to **false**.
 
 `generate({ words: 3 })` will return:
@@ -89,6 +91,15 @@ The `options` argument object can have properties
   raw: [ 'exciting', 'cooperative', 'legal', 'lackadaisical', 'blood', 4099 ],
   dashed: 'exciting-cooperative-legal-lackadaisical-blood-4099',
   spaced: 'exciting cooperative legal lackadaisical blood 4099'
+}
+```
+
+`generate({ words: 2, number: 6 })` will return:
+```javascript
+{
+  raw: [ 'woozy', 'fire', 152343 ],
+  dashed: 'woozy-fire-152343',
+  spaced: 'woozy fire 152343'
 }
 ```
 

--- a/spec/generator.spec.js
+++ b/spec/generator.spec.js
@@ -97,6 +97,16 @@ describe('generator', function () {
         expect(_.includes(nouns, projName.raw[1])).to.be(true);
         expect(projName.raw[0].substring(0, 1).toLowerCase() === projName.raw[1].substring(0, 1).toLowerCase()).to.be(true);
       });
+
+      it('with {words: 2, number: 5}, has 1 adjective and 1 noun and up to 5 numeric digits', function() {
+        projName = generate({words: 2, number: 5, alliterative: true});
+        expect(projName.raw.length).to.be(3);
+        expect(_.includes(adjectives, projName.raw[0])).to.be(true);
+        expect(_.includes(nouns, projName.raw[1])).to.be(true);
+        expect(typeof projName.raw[2]).to.be('number');
+        expect(projName.raw[2]).to.be.above(0);
+        expect(projName.raw[2]).to.be.below(100000);
+      });
     });
   });
 

--- a/src/generator-bin.js
+++ b/src/generator-bin.js
@@ -6,7 +6,7 @@ const program = require('commander')
 program
     .version('1.0.0')
     .option('-w, --words [num]', 'number of words [2]', 2)
-    .option('-n, --numbers', 'use numbers')
+    .option('-n, --numbers [num]', 'use numbers')
     .option('-a, --alliterative', 'use alliterative')
     .option('-o, --output [output]', 'output type [raw|dashed|spaced]', /^(raw|dashed|spaced)$/i)
     .parse(process.argv)

--- a/src/generator.js
+++ b/src/generator.js
@@ -38,7 +38,10 @@ function getRawProjName(options) {
     raw.push(_.sample(nouns).toLowerCase());
 
   if (options.number) {
-    raw.push(_.random(1, 9999));
+    // `true` check for backwards-compat support of boolean value, generates 4 digits (1-9999)
+    var exponent = options.number === true ? 4 : parseInt(options.number, 10);
+    exponent = Math.min(20, Math.max(1, Math.abs(exponent)));
+    raw.push(_.random(1, Math.pow(10, exponent) - 1));
   }
   return raw;
 }


### PR DESCRIPTION
Return an exponential length for the numeric suffix.

Backwards-compatible to allow original `true` to return a numeric length of 4 (1-9999).

Includes updated tests.